### PR TITLE
Fixed Unknown format of "time" command

### DIFF
--- a/src/arch/time.c
+++ b/src/arch/time.c
@@ -49,5 +49,4 @@ void show_time() {
 	}   
     
 	kprintf("%03i/%03i/'%03i %03i:%03i:%03i UTC\n", day, month, year, hour, minute, second);
-   
 }

--- a/src/arch/time.c
+++ b/src/arch/time.c
@@ -1,6 +1,5 @@
 #include <shell/shell.h>
 #include <arch/time.h>
-
 #define outb_p(value,port) \
 __asm__ ("outb %%al,%%dx\n" \
 		"\tjmp 1f\n" \
@@ -17,12 +16,38 @@ _v; \
 })
 
 #define CMOS_READ(addr) ({ \
-    outb_p(0x80|addr,0x70); \
+    outb_p(addr,0x70); \
     inb_p(0x71); \
 })
 
+uint8_t hour, minute, second, registerB, day, month, year;
 void show_time() {
-    kprintf("%03i/%03i/%03i %03i:%03i:%03i\n",
-            CMOS_READ(8), CMOS_READ(7), CMOS_READ(9),
-            CMOS_READ(4), CMOS_READ(2), CMOS_READ(0));
+	// referenced from : https://wiki.osdev.org/CMOS#RTC_Update_In_Progress
+	// reading values from associated CMOS register number containing respective data
+	hour = CMOS_READ(0x04);
+	minute = CMOS_READ(0x02);
+	second = CMOS_READ(0x00);
+
+	day = CMOS_READ(0x07);
+	month = CMOS_READ(0x08);
+	year = CMOS_READ(0x09);
+	
+
+	// Converting BCD to binary values
+	second = (second & 0x0F) + ((second / 16) * 10);
+	minute = (minute & 0x0F) + ((minute / 16) * 10);
+	hour = ( (hour & 0x0F) + (((hour & 0x70) / 16) * 10) ) | (hour & 0x80);
+
+	day = (day & 0x0F) + ((day / 16) * 10);
+	month = (month & 0x0F) + ((month / 16) * 10);
+	year = (year & 0x0F) + ((year / 16) * 10);
+	
+	// Converting 12 hour clock to 24 hour clock 
+	registerB = CMOS_READ(0x0B);
+	if (!(registerB & 0x02) && (hour & 0x80)) {
+		hour = ((hour & 0x7F) + 12) % 24;
+	}   
+    
+	kprintf("%03i/%03i/'%03i %03i:%03i:%03i UTC\n", day, month, year, hour, minute, second);
+   
 }

--- a/src/arch/time.c
+++ b/src/arch/time.c
@@ -45,7 +45,7 @@ void show_time() {
 	year = (year & 0x0F) + ((year / 16) * 10);
 	
 	// Converting 12 hour clock to 24 hour clock 
-	if (!(cMOS_READ(0x0B) & 0x02) && (hour & 0x80)) {
+	if (!(CMOS_READ(0x0B) & 0x02) && (hour & 0x80)) {
 		hour = ((hour & 0x7F) + 12) % 24;
 	}   
     

--- a/src/arch/time.c
+++ b/src/arch/time.c
@@ -24,7 +24,7 @@ void show_time() {
 	// referenced from : https://wiki.osdev.org/CMOS#RTC_Update_In_Progress
 	// reading values from associated CMOS register number containing respective data
 	
-	uint8_t hour, minute, second, registerB, day, month, year;
+	uint8_t hour, minute, second, day, month, year;
 	
 	hour = CMOS_READ(0x04);
 	minute = CMOS_READ(0x02);
@@ -45,8 +45,7 @@ void show_time() {
 	year = (year & 0x0F) + ((year / 16) * 10);
 	
 	// Converting 12 hour clock to 24 hour clock 
-	registerB = CMOS_READ(0x0B);
-	if (!(registerB & 0x02) && (hour & 0x80)) {
+	if (!(cMOS_READ(0x0B) & 0x02) && (hour & 0x80)) {
 		hour = ((hour & 0x7F) + 12) % 24;
 	}   
     

--- a/src/arch/time.c
+++ b/src/arch/time.c
@@ -20,10 +20,12 @@ _v; \
     inb_p(0x71); \
 })
 
-uint8_t hour, minute, second, registerB, day, month, year;
 void show_time() {
 	// referenced from : https://wiki.osdev.org/CMOS#RTC_Update_In_Progress
 	// reading values from associated CMOS register number containing respective data
+	
+	uint8_t hour, minute, second, registerB, day, month, year;
+	
 	hour = CMOS_READ(0x04);
 	minute = CMOS_READ(0x02);
 	second = CMOS_READ(0x00);


### PR DESCRIPTION
The data coming from CMOS registers used to be in BCD format which needs to be converted to binary format. And so the time format that was previously shown was not understandable for us.